### PR TITLE
Fixing problem with high water mark and adding some debug logging

### DIFF
--- a/crashmail/handle.c
+++ b/crashmail/handle.c
@@ -1228,6 +1228,9 @@ bool HandleNetmail(struct MemMessage *mm)
 
       if(aka || (config.cfg_Flags & CFG_NOROUTE))
       {
+        if(config.cfg_Flags & CFG_NOROUTE) {
+          LogWrite(4, DEBUG, "NOROUTE is specified in config. Importing message instead of routing.");
+        }
          for(tmparea=(struct Area *)config.AreaList.First;tmparea;tmparea=tmparea->Next)
             if(tmparea->AreaType == AREATYPE_NETMAIL) break;
       }

--- a/crashmail/mb_msg.c
+++ b/crashmail/mb_msg.c
@@ -60,9 +60,9 @@ bool msg_afterfunc(bool success)
 
    if(success && (config.cfg_msg_Flags & CFG_MSG_HIGHWATER)) {
      for(ma=(struct msg_Area *)msg_AreaList.First;ma;ma=ma->Next) {
-       LogWrite(5, DEBUG, "Area %s, old hwm = %d, new hwm = %d",
-                ma->area->Tagname, ma->OldHighWater, ma->HighWater);
        if(ma->HighWater != ma->OldHighWater) {
+         LogWrite(5, DEBUG, "Updating hwm for area %s, old = %d, new = %d",
+                  ma->area->Tagname, ma->OldHighWater, ma->HighWater);
          msg_WriteHighWater(ma);
        }
      }

--- a/crashmail/mb_msg.c
+++ b/crashmail/mb_msg.c
@@ -58,10 +58,15 @@ bool msg_afterfunc(bool success)
 {
    struct msg_Area *ma;
 
-   if(success && (config.cfg_msg_Flags & CFG_MSG_HIGHWATER))
-      for(ma=(struct msg_Area *)msg_AreaList.First;ma;ma=ma->Next)
-         if(ma->HighWater != ma->OldHighWater)
-            msg_WriteHighWater(ma);
+   if(success && (config.cfg_msg_Flags & CFG_MSG_HIGHWATER)) {
+     for(ma=(struct msg_Area *)msg_AreaList.First;ma;ma=ma->Next) {
+       LogWrite(5, DEBUG, "Area %s, old hwm = %d, new hwm = %d",
+                ma->area->Tagname, ma->OldHighWater, ma->HighWater);
+       if(ma->HighWater != ma->OldHighWater) {
+         msg_WriteHighWater(ma);
+       }
+     }
+   }
 
    return(TRUE);
 }
@@ -175,6 +180,7 @@ bool msg_ExportMSGNum(struct Area *area,uint32_t num,bool (*handlefunc)(struct M
 	uint16_t oldattr;
    struct msg_Area *ma;
 
+   LogWrite(5, DEBUG, "Inspecting message %d", num);
    if(!(ma=msg_getarea(area)))
       return(FALSE);
 
@@ -187,6 +193,7 @@ bool msg_ExportMSGNum(struct Area *area,uint32_t num,bool (*handlefunc)(struct M
    if(!(fh=osOpen(buf,MODE_OLDFILE)))
    {
       /* Message doesn't exist */
+     LogWrite(5, DEBUG, "Can't open file '%s' for reading, skipping message.", buf);
       return(TRUE);
    }
 
@@ -201,6 +208,12 @@ bool msg_ExportMSGNum(struct Area *area,uint32_t num,bool (*handlefunc)(struct M
 	{
 		if((Msg.Attr & FLAG_SENT) || !(Msg.Attr & FLAG_LOCAL))
 		{
+                  if(Msg.Attr & FLAG_SENT) {
+                    LogWrite(5, DEBUG, "Skipping message since it's already sent.");
+                  }
+                  if(Msg.Attr & FLAG_LOCAL) {
+                    LogWrite(5, DEBUG, "Skipping message since it's local.");
+                  }
 			/* Don't touch if the message is sent or not local */
 			osClose(fh);
    	   return(TRUE);

--- a/crashmail/mb_msg.c
+++ b/crashmail/mb_msg.c
@@ -161,6 +161,7 @@ bool msg_exportfunc(struct Area *area,bool (*handlefunc)(struct MemMessage *mm))
       if(!msg_ExportMSGNum(area,start,handlefunc,FALSE))
          return(FALSE);
 
+      ma->HighWater = start;
       start++;
    }
 
@@ -328,7 +329,6 @@ bool msg_ExportMSGNum(struct Area *area,uint32_t num,bool (*handlefunc)(struct M
 		}
 		else
 		{
-         ma->HighWater=num;
 
          Msg.Attr|=FLAG_SENT;
 

--- a/crashmail/scan.c
+++ b/crashmail/scan.c
@@ -51,27 +51,28 @@ bool Scan(void)
    if(!BeforeScanToss())
       return(FALSE);
 
-   for(area=(struct Area *)config.AreaList.First;area && !ctrlc;area=area->Next)
-      if(area->Messagebase && (area->AreaType == AREATYPE_ECHOMAIL || area->AreaType == AREATYPE_NETMAIL))
-		{
-         if(area->Messagebase->exportfunc)
-			{
-            if(area->AreaType == AREATYPE_NETMAIL && (config.cfg_Flags & CFG_NOEXPORTNETMAIL))
-            {
-               printf("Skipping area %s (NOEXPORTNETMAIL is set)\n", area->Tagname);
-            }
-            else
-            {
-               printf("Scanning area %s\n",area->Tagname);
-
-	            if(!(*area->Messagebase->exportfunc)(area,ScanHandle))
-   	         {
-          	      AfterScanToss(FALSE);
-            	   return(FALSE);
-	            }
-            }
+   for(area=(struct Area *)config.AreaList.First;area && !ctrlc;area=area->Next) {
+     LogWrite(5, DEBUG, "Found area %s", area->Tagname);
+     if(area->Messagebase && (area->AreaType == AREATYPE_ECHOMAIL || area->AreaType == AREATYPE_NETMAIL)) {
+       if(area->Messagebase->exportfunc) {
+         if(area->AreaType == AREATYPE_NETMAIL && (config.cfg_Flags & CFG_NOEXPORTNETMAIL)) {
+           LogWrite(4, DEBUG, "Skipping area %s (NOEXPORTNETMAIL is set)", area->Tagname);
+         } else {
+           LogWrite(4, DEBUG, "Scanning area %s", area->Tagname);
+           
+           if(!(*area->Messagebase->exportfunc)(area,ScanHandle))
+             {
+               AfterScanToss(FALSE);
+               return(FALSE);
+             }
          }
-      }
+       } else {
+         LogWrite(5, DEBUG, "Skipping area, it has no exportfunc.");
+       }
+     } else {
+       LogWrite(5, DEBUG, "Skiping area because it has no messagebase or area type is not echomail or netmail..");
+     }
+   }
 
    if(ctrlc)
    {


### PR DESCRIPTION
Hi Lars,

I have made a few changes to Crashmail that you may want to consider including. The only functional change is to make it update the high water mark in 1.msg every time an area is scanned. Previously it would only do this when it exported a message that were created on the local system. This meant that for any area where no messages were written on the local system (people were only reading) the 1.msg file would never get created. So every time crashmail scans that area it would need to scan every single message file, over and over again.

I also added some debug logging that was helpful when getting crashmail to work on my system. It probably would be useful to others as well when trying to figure out why crashmail is not doing what you think it should do.

/Niklas
